### PR TITLE
feat: allow fallback to default storage class

### DIFF
--- a/charts/mongodb-community-cluster/Chart.yaml
+++ b/charts/mongodb-community-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb-community-cluster
 description: A Helm chart for deploying MongoDBCommunity cluster (community-operator)
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 6.0.2
 icon: https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original.svg
 

--- a/charts/mongodb-community-cluster/templates/mongodb-community-cluster.yaml
+++ b/charts/mongodb-community-cluster/templates/mongodb-community-cluster.yaml
@@ -64,7 +64,9 @@ spec:
             resources:
               requests:
                 storage: {{ .Values.mongod.persistence.data.size }}
-            storageClassName: {{ .Values.mongod.persistence.data.storageClassName | default "gp2" }}
+            {{- if .Values.mongod.persistence.data.storageClassName }}
+            storageClassName: {{ .Values.mongod.persistence.data.storageClassName }}
+            {{- end }}
         - metadata:
             name: logs-volume
           spec:
@@ -73,6 +75,8 @@ spec:
             resources:
               requests:
                 storage: {{ .Values.mongod.persistence.logs.size }}
-            storageClassName: {{ .Values.mongod.persistence.logs.storageClassName | default "gp2" }}
+            {{- if .Values.mongod.persistence.logs.storageClassName }}
+            storageClassName: {{ .Values.mongod.persistence.logs.storageClassName }}
+            {{- end }}
   users:
     {{- include "mongodb-users" . | nindent 4 }}

--- a/charts/mongodb-community-cluster/values.yaml
+++ b/charts/mongodb-community-cluster/values.yaml
@@ -30,10 +30,10 @@ mongod:
       size: 5Gi
       accessModes:
         - ReadWriteOnce
-      storageClassName: ""
+      storageClassName: gp2
     logs:
       size: 1Gi
-      storageClassName: ""
+      storageClassName: gp2
       accessModes:
         - ReadWriteOnce
   resources:


### PR DESCRIPTION
# Problem
K8s clusters can define a default storage class that will be used to create persistent volumes. The _mongodb-community-cluster_ chart forces the storage class to be _gp2_. This will prevent the helm chart from making use of the default mechanism of k8s.

# Solution
This PR will move the _gp2_ default value to the _values.yaml_ file so that it can be ridden. The default storage class registered in k8s can be invoked by setting `storageClassName: ""` or `storageClassName: null` in _values.yaml_.