### PR TITLE
fix(argo-watcher): give migration hook a dedicated ServiceAccount

### DIFF
--- a/charts/argo-watcher/Chart.yaml
+++ b/charts/argo-watcher/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 sources:
 - https://github.com/shini4i/argo-watcher
 - https://github.com/shini4i/charts/tree/main/charts/argo-watcher
-version: 1.0.11
+version: 1.1.0
 keywords:
 - argocd
 - gitops
@@ -22,5 +22,5 @@ annotations:
     fingerprint: FF1E9948F6234DC6D70AB47BF509F29B63C1DC2B
     url: https://shini4i.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update argo-watcher app version from v0.12.0 to v0.12.1
+    - kind: fixed
+      description: Migration hook now uses a dedicated hook-scoped ServiceAccount so its pod no longer fails with "serviceaccount not found"

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -1,6 +1,6 @@
 # argo-watcher
 
-![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.1](https://img.shields.io/badge/AppVersion-v0.12.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.1](https://img.shields.io/badge/AppVersion-v0.12.1-informational?style=flat-square)
 
 A Helm chart for deploying argo-watcher
 

--- a/charts/argo-watcher/templates/migration-serviceaccount.yaml
+++ b/charts/argo-watcher/templates/migration-serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.postgres.enabled }}
+{{/*
+Dedicated ServiceAccount for the DB migration hook.
+
+It is a hook itself (weight -5, ahead of the migration Job's weight 0) so it
+exists before the Job's pod is scheduled -- a plain release-managed SA is only
+applied after the pre-install/pre-upgrade phase, which is what makes the Job's
+pod fail with "serviceaccount not found".
+
+The migration only talks to Postgres and needs no Kubernetes API access, so the
+token is never mounted.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argo-watcher.fullname" . }}-migration
+  labels:
+    {{- include "argo-watcher.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/argo-watcher/templates/migrations.yaml
+++ b/charts/argo-watcher/templates/migrations.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "argo-watcher.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
@@ -15,7 +16,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "argo-watcher.serviceAccountName" . }}
+      serviceAccountName: {{ include "argo-watcher.fullname" . }}-migration
       securityContext:
         {{- toYaml .Values.migration.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/argo-watcher/tests/migration-serviceaccount_test.yaml
+++ b/charts/argo-watcher/tests/migration-serviceaccount_test.yaml
@@ -1,0 +1,45 @@
+suite: test migration service account
+templates:
+  - templates/migration-serviceaccount.yaml
+tests:
+  - it: should not be created when postgres is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be created as a hook when postgres is enabled
+    set:
+      postgres:
+        enabled: true
+        secretName: db-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-migration
+
+  - it: should run before the migration Job via hook weight
+    set:
+      postgres:
+        enabled: true
+        secretName: db-secret
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": pre-install,pre-upgrade
+            "helm.sh/hook-weight": "-5"
+            "helm.sh/hook-delete-policy": before-hook-creation
+
+  - it: should never mount an API token
+    set:
+      postgres:
+        enabled: true
+        secretName: db-secret
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/charts/argo-watcher/tests/migrations_test.yaml
+++ b/charts/argo-watcher/tests/migrations_test.yaml
@@ -28,6 +28,7 @@ tests:
           path: metadata.annotations
           value:
             "helm.sh/hook": pre-install,pre-upgrade
+            "helm.sh/hook-weight": "0"
             "helm.sh/hook-delete-policy": before-hook-creation
       - equal:
           path: spec.template.spec.containers[0].image
@@ -68,9 +69,9 @@ tests:
       - equal:
           path: spec.template.spec.restartPolicy
           value: OnFailure
-      - matchRegex:
+      - equal:
           path: spec.template.spec.serviceAccountName
-          pattern: ".*argo-watcher"
+          value: RELEASE-NAME-argo-watcher-migration
 
   - it: should expose DB_PASSWORD from a specific key in a specific secret
     set:


### PR DESCRIPTION
The pre-install/pre-upgrade migration Job referenced the app's ServiceAccount, a normal release resource applied only after the hook phase, so the Job's pod failed with "serviceaccount not found".

Add a dedicated hook-scoped ServiceAccount at hook-weight -5 (Job at 0) so it is created first, with automountServiceAccountToken disabled since the migration only talks to Postgres and needs no Kubernetes API access.