### PR TITLE
feat(argo-watcher): add optional argo-watcher-mcp deployment

### DIFF
--- a/charts/argo-watcher/.helmignore
+++ b/charts/argo-watcher/.helmignore
@@ -23,3 +23,5 @@
 .vscode/
 # Helm unittest files
 tests/
+# helm-docs source template
+*.gotmpl

--- a/charts/argo-watcher/Chart.yaml
+++ b/charts/argo-watcher/Chart.yaml
@@ -4,12 +4,14 @@ description: A Helm chart for deploying argo-watcher
 type: application
 sources:
 - https://github.com/shini4i/argo-watcher
+- https://github.com/shini4i/argo-watcher-mcp
 - https://github.com/shini4i/charts/tree/main/charts/argo-watcher
-version: 1.1.2
+version: 1.2.0
 keywords:
 - argocd
 - gitops
 - automation
+- mcp
 kubeVersion: '>=1.21.0-0'
 appVersion: v0.13.0
 maintainers:
@@ -22,5 +24,5 @@ annotations:
     fingerprint: FF1E9948F6234DC6D70AB47BF509F29B63C1DC2B
     url: https://shini4i.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update argo-watcher app version from v0.12.2 to v0.13.0
+    - kind: added
+      description: Optional argo-watcher-mcp deployment, enabled via mcp.enabled

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -1,6 +1,6 @@
 # argo-watcher
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
 
 A Helm chart for deploying argo-watcher
 
@@ -13,11 +13,132 @@ A Helm chart for deploying argo-watcher
 ## Source Code
 
 * <https://github.com/shini4i/argo-watcher>
+* <https://github.com/shini4i/argo-watcher-mcp>
 * <https://github.com/shini4i/charts/tree/main/charts/argo-watcher>
 
 ## Requirements
 
 Kubernetes: `>=1.21.0-0`
+
+## MCP server
+
+Setting `mcp.enabled: true` deploys [argo-watcher-mcp](https://github.com/shini4i/argo-watcher-mcp),
+which exposes argo-watcher's read-only API as [Model Context Protocol](https://modelcontextprotocol.io)
+tools so AI agents can ask what was deployed, when, by whom, and whether it
+succeeded. Upstream describes the project as a proof of concept.
+
+It runs as its own Deployment rather than as a sidecar, so its image and
+configuration can change without restarting argo-watcher — which matters because
+argo-watcher is a StatefulSet that holds task history in memory unless
+`postgres.enabled` is set.
+
+The image tag lives in `mcp.image.tag` and is pinned independently of the chart
+`appVersion`, which tracks argo-watcher itself. The `get_reachability` tool needs
+argo-watcher v0.13.0 or newer.
+
+### Exposing the MCP server
+
+> [!WARNING]
+> **argo-watcher-mcp performs no authentication and no authorization.** Every
+> request is anonymous, there is no token or OIDC support, and no per-tool
+> permission model. Anything that can reach the endpoint can read your full
+> deployment history and instance configuration.
+
+Enabling `oidc.*` does not change this. The endpoints the MCP server reads —
+`GET /api/v1/tasks`, `/version`, `/config`, `/reachability` and `GET /deploy-lock`
+— are registered on argo-watcher without auth middleware whether or not OIDC is
+enabled, so the MCP server discloses nothing argo-watcher's own API does not
+already serve unauthenticated. What an Ingress changes is *who can reach it*.
+
+What an anonymous caller can read: every deployment's application, image tags,
+author, timestamp and outcome, including rollbacks; the deploy-lock state;
+ArgoCD and state-backend reachability; and an allowlisted subset of the
+instance's configuration. The MCP server strips `user:password@` credentials
+from URL-valued config fields, but `ARGO_URL_ALIAS` and `DOCKER_IMAGES_PROXY`
+are forwarded as argo-watcher reports them. The server cannot create deployments
+or change the deploy lock, so the exposure is disclosure and request load, not
+tampering.
+
+Pick the least exposure that works for you.
+
+**Port-forward — nothing is exposed.** Enough for a developer workstation and
+the recommended default:
+
+```console
+kubectl --namespace <namespace> port-forward svc/<release>-argo-watcher-mcp 8000:80
+```
+
+Then point the MCP client at `http://localhost:8000`.
+
+**In-cluster only.** An agent running in another namespace reaches the endpoint
+without any Ingress. With `networkPolicies.enabled: true`, grant that namespace
+access explicitly:
+
+```yaml
+networkPolicies:
+  enabled: true
+mcp:
+  enabled: true
+  networkPolicies:
+    additionalRules:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: my-agent-namespace
+```
+
+`mcp.networkPolicies.additionalRules` is deliberately separate from
+`networkPolicies.additionalRules`, and the MCP pods carry their own
+`app.kubernetes.io/name` label, so widening access to the MCP endpoint cannot
+also widen access to the argo-watcher API.
+
+**Ingress, behind an authenticating proxy.** Since the endpoint authenticates
+nobody, the proxy in front of it is the only thing standing between your
+deployment history and the internet. Terminate authentication there — for
+example with [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) or
+your ingress controller's external-auth support — and keep `mcp.ingress.hosts`
+off any public wildcard DNS you do not control:
+
+```yaml
+mcp:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.example.com/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.example.com/oauth2/start?rd=$escaped_request_uri"
+    hosts:
+      - host: argo-watcher-mcp.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: argo-watcher-mcp-tls
+        hosts:
+          - argo-watcher-mcp.example.com
+```
+
+With `networkPolicies.enabled: true`, the ingress controller also needs an
+`mcp.networkPolicies.additionalRules` entry for its own namespace. Without one
+the deny-by-default policy drops its traffic and the Ingress returns 502 with
+nothing pointing at the NetworkPolicy as the cause.
+
+Two transport details to check against your proxy when you do this: the MCP
+endpoint is mounted at `/`, so it cannot share a host with another backend
+without a path prefix, and its streamable transport holds a long-lived
+server-sent-events stream open — a proxy that buffers responses or applies a
+short read timeout will break sessions rather than fail outright.
+
+### Metrics
+
+The MCP server serves Prometheus metrics on `/metrics` on the same port as the
+MCP endpoint itself. Set `mcp.podMonitor.enabled: true` to scrape it.
+OpenTelemetry export is configured through `mcp.extraEnvs` using the upstream
+`OTEL_*` variables.
+
+Because the two share a port, a NetworkPolicy rule that lets a monitoring
+namespace scrape `/metrics` also lets it call every MCP tool. The argo-watcher
+PodMonitor has the same property.
 
 ## Values
 
@@ -47,6 +168,46 @@ Kubernetes: `>=1.21.0-0`
 | ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"path":"/healthz","periodSeconds":30,"timeoutSeconds":5}` | Liveness probe configuration |
 | logLevel | string | `"info"` |  |
+| mcp.affinity | object | `{}` |  |
+| mcp.enabled | bool | `false` | Deploy the MCP server alongside argo-watcher |
+| mcp.extraEnvs | list | `[]` | Additional environment variables for the MCP container, e.g. the OTEL_* settings (supports both value and valueFrom) |
+| mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
+| mcp.image.repository | string | `"ghcr.io/shini4i/argo-watcher-mcp"` |  |
+| mcp.image.tag | string | `"v0.3.0"` | MCP server image tag. Pinned here rather than derived from the chart appVersion, which tracks argo-watcher itself. Required when mcp is enabled. |
+| mcp.ingress.annotations | object | `{}` |  |
+| mcp.ingress.className | string | `""` |  |
+| mcp.ingress.enabled | bool | `false` | Expose the MCP endpoint via Ingress. The endpoint is UNAUTHENTICATED; put an authenticating proxy in front of it. |
+| mcp.ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| mcp.ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| mcp.ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| mcp.ingress.tls | list | `[]` |  |
+| mcp.livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"path":"/healthz","periodSeconds":30,"timeoutSeconds":5}` | Liveness probe configuration. /healthz reports only whether the MCP process is up; it does not depend on argo-watcher. |
+| mcp.networkPolicies.additionalRules | list | `[]` | Additional ingress rules granting access to the MCP container port. Created when networkPolicies.enabled is true; kept separate from networkPolicies.additionalRules so opening the MCP endpoint to a wider audience cannot also open the argo-watcher API. |
+| mcp.nodeSelector | object | `{}` |  |
+| mcp.podAnnotations | object | `{}` |  |
+| mcp.podMonitor.enabled | bool | `false` |  |
+| mcp.podMonitor.labels | object | `{}` |  |
+| mcp.podSecurityContext | object | `{}` |  |
+| mcp.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10,"timeoutSeconds":3}` | Readiness probe configuration. Defaults to /healthz so the server keeps serving while argo-watcher is down, which is what lets its get_reachability tool report the outage. Set path to /readyz to gate readiness on argo-watcher being reachable instead, accepting that the endpoint disappears with it. |
+| mcp.replicaCount | int | `1` |  |
+| mcp.requestTimeout | string | `"15s"` | How long the MCP server waits for an argo-watcher API response |
+| mcp.resources | object | `{}` |  |
+| mcp.revisionHistory | int | `1` |  |
+| mcp.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| mcp.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| mcp.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| mcp.securityContext.runAsNonRoot | bool | `true` |  |
+| mcp.securityContext.runAsUser | int | `65532` |  |
+| mcp.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| mcp.service.containerPort | int | `8000` |  |
+| mcp.service.port | int | `80` |  |
+| mcp.service.type | string | `"ClusterIP"` |  |
+| mcp.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| mcp.serviceAccount.automountServiceAccountToken | bool | `false` | Whether to automount the service account token. The MCP server never calls the Kubernetes API. |
+| mcp.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| mcp.serviceAccount.name | string | `""` | The name of the service account to use. Required when create is false. |
+| mcp.tolerations | list | `[]` |  |
+| mcp.topologySpreadConstraints | list | `[]` |  |
 | migration.backoffLimit | int | `5` |  |
 | migration.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | migration.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -176,7 +176,7 @@ PodMonitor has the same property.
 | mcp.image.tag | string | `"v0.3.0"` | MCP server image tag. Pinned here rather than derived from the chart appVersion, which tracks argo-watcher itself. Required when mcp is enabled. |
 | mcp.ingress.annotations | object | `{}` |  |
 | mcp.ingress.className | string | `""` |  |
-| mcp.ingress.enabled | bool | `false` | Expose the MCP endpoint via Ingress. The endpoint is UNAUTHENTICATED; put an authenticating proxy in front of it. |
+| mcp.ingress.enabled | bool | `false` | Expose the MCP endpoint via Ingress. Anything that can reach it can read the full deployment history and instance configuration, so put an authenticating proxy in front — see "Exposing the MCP server" in the README. |
 | mcp.ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | mcp.ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | mcp.ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
@@ -188,7 +188,7 @@ PodMonitor has the same property.
 | mcp.podMonitor.enabled | bool | `false` |  |
 | mcp.podMonitor.labels | object | `{}` |  |
 | mcp.podSecurityContext | object | `{}` |  |
-| mcp.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10,"timeoutSeconds":3}` | Readiness probe configuration. Defaults to /healthz so the server keeps serving while argo-watcher is down, which is what lets its get_reachability tool report the outage. Set path to /readyz to gate readiness on argo-watcher being reachable instead, accepting that the endpoint disappears with it. |
+| mcp.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10,"timeoutSeconds":3}` | Readiness probe configuration. /healthz keeps the server serving while argo-watcher is down, so its get_reachability tool can report the outage; /readyz gates readiness on argo-watcher instead, and drops out with it. |
 | mcp.replicaCount | int | `1` |  |
 | mcp.requestTimeout | string | `"15s"` | How long the MCP server waits for an argo-watcher API response |
 | mcp.resources | object | `{}` |  |

--- a/charts/argo-watcher/README.md.gotmpl
+++ b/charts/argo-watcher/README.md.gotmpl
@@ -1,0 +1,139 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## MCP server
+
+Setting `mcp.enabled: true` deploys [argo-watcher-mcp](https://github.com/shini4i/argo-watcher-mcp),
+which exposes argo-watcher's read-only API as [Model Context Protocol](https://modelcontextprotocol.io)
+tools so AI agents can ask what was deployed, when, by whom, and whether it
+succeeded. Upstream describes the project as a proof of concept.
+
+It runs as its own Deployment rather than as a sidecar, so its image and
+configuration can change without restarting argo-watcher — which matters because
+argo-watcher is a StatefulSet that holds task history in memory unless
+`postgres.enabled` is set.
+
+The image tag lives in `mcp.image.tag` and is pinned independently of the chart
+`appVersion`, which tracks argo-watcher itself. The `get_reachability` tool needs
+argo-watcher v0.13.0 or newer.
+
+### Exposing the MCP server
+
+> [!WARNING]
+> **argo-watcher-mcp performs no authentication and no authorization.** Every
+> request is anonymous, there is no token or OIDC support, and no per-tool
+> permission model. Anything that can reach the endpoint can read your full
+> deployment history and instance configuration.
+
+Enabling `oidc.*` does not change this. The endpoints the MCP server reads —
+`GET /api/v1/tasks`, `/version`, `/config`, `/reachability` and `GET /deploy-lock`
+— are registered on argo-watcher without auth middleware whether or not OIDC is
+enabled, so the MCP server discloses nothing argo-watcher's own API does not
+already serve unauthenticated. What an Ingress changes is *who can reach it*.
+
+What an anonymous caller can read: every deployment's application, image tags,
+author, timestamp and outcome, including rollbacks; the deploy-lock state;
+ArgoCD and state-backend reachability; and an allowlisted subset of the
+instance's configuration. The MCP server strips `user:password@` credentials
+from URL-valued config fields, but `ARGO_URL_ALIAS` and `DOCKER_IMAGES_PROXY`
+are forwarded as argo-watcher reports them. The server cannot create deployments
+or change the deploy lock, so the exposure is disclosure and request load, not
+tampering.
+
+Pick the least exposure that works for you.
+
+**Port-forward — nothing is exposed.** Enough for a developer workstation and
+the recommended default:
+
+```console
+kubectl --namespace <namespace> port-forward svc/<release>-argo-watcher-mcp 8000:80
+```
+
+Then point the MCP client at `http://localhost:8000`.
+
+**In-cluster only.** An agent running in another namespace reaches the endpoint
+without any Ingress. With `networkPolicies.enabled: true`, grant that namespace
+access explicitly:
+
+```yaml
+networkPolicies:
+  enabled: true
+mcp:
+  enabled: true
+  networkPolicies:
+    additionalRules:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: my-agent-namespace
+```
+
+`mcp.networkPolicies.additionalRules` is deliberately separate from
+`networkPolicies.additionalRules`, and the MCP pods carry their own
+`app.kubernetes.io/name` label, so widening access to the MCP endpoint cannot
+also widen access to the argo-watcher API.
+
+**Ingress, behind an authenticating proxy.** Since the endpoint authenticates
+nobody, the proxy in front of it is the only thing standing between your
+deployment history and the internet. Terminate authentication there — for
+example with [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) or
+your ingress controller's external-auth support — and keep `mcp.ingress.hosts`
+off any public wildcard DNS you do not control:
+
+```yaml
+mcp:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.example.com/oauth2/auth"
+      nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.example.com/oauth2/start?rd=$escaped_request_uri"
+    hosts:
+      - host: argo-watcher-mcp.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: argo-watcher-mcp-tls
+        hosts:
+          - argo-watcher-mcp.example.com
+```
+
+With `networkPolicies.enabled: true`, the ingress controller also needs an
+`mcp.networkPolicies.additionalRules` entry for its own namespace. Without one
+the deny-by-default policy drops its traffic and the Ingress returns 502 with
+nothing pointing at the NetworkPolicy as the cause.
+
+Two transport details to check against your proxy when you do this: the MCP
+endpoint is mounted at `/`, so it cannot share a host with another backend
+without a path prefix, and its streamable transport holds a long-lived
+server-sent-events stream open — a proxy that buffers responses or applies a
+short read timeout will break sessions rather than fail outright.
+
+### Metrics
+
+The MCP server serves Prometheus metrics on `/metrics` on the same port as the
+MCP endpoint itself. Set `mcp.podMonitor.enabled: true` to scrape it.
+OpenTelemetry export is configured through `mcp.extraEnvs` using the upstream
+`OTEL_*` variables.
+
+Because the two share a port, a NetworkPolicy rule that lets a monitoring
+namespace scrape `/metrics` also lets it call every MCP tool. The argo-watcher
+PodMonitor has the same property.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/argo-watcher/templates/NOTES.txt
+++ b/charts/argo-watcher/templates/NOTES.txt
@@ -21,3 +21,23 @@ Database: postgres ({{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .
 
 State storage: in-memory (data will be lost on pod restart)
 {{- end }}
+
+{{- if .Values.mcp.enabled }}
+
+The MCP server is deployed at {{ include "argo-watcher.mcp.fullname" . }}.
+
+Point an MCP client at http://localhost:8000 after running:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "argo-watcher.mcp.fullname" . }} 8000:{{ .Values.mcp.service.port }}
+{{- if .Values.mcp.ingress.enabled }}
+
+  WARNING: mcp.ingress is enabled and argo-watcher-mcp performs NO
+  authentication or authorization. Anyone who can reach the addresses below can
+  read your full deployment history and instance configuration. Keep an
+  authenticating proxy in front of it.
+{{- range $host := .Values.mcp.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.mcp.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/argo-watcher/templates/_helpers.tpl
+++ b/charts/argo-watcher/templates/_helpers.tpl
@@ -61,6 +61,63 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Name of the MCP server workload. Kept distinct from the argo-watcher name so the
+argo-watcher selectors, NetworkPolicies and PodMonitor never match MCP pods.
+
+The suffix is appended after truncating the base to 59 characters, not before:
+truncating the joined string would collapse any 63-character name back onto the
+argo-watcher name, silently giving both workloads the same selector labels. The
+one input this does not separate is a 63-character name that already ends in
+"-mcp".
+*/}}
+{{- define "argo-watcher.mcp.name" -}}
+{{- printf "%s-mcp" (include "argo-watcher.name" . | trunc 59 | trimSuffix "-") }}
+{{- end }}
+
+{{- define "argo-watcher.mcp.fullname" -}}
+{{- printf "%s-mcp" (include "argo-watcher.fullname" . | trunc 59 | trimSuffix "-") }}
+{{- end }}
+
+{{/*
+Resolved MCP server image tag. The chart appVersion tracks argo-watcher, so the
+MCP image has no appVersion to fall back on.
+*/}}
+{{- define "argo-watcher.mcp.tag" -}}
+{{- if not .Values.mcp.image.tag }}
+{{- fail "mcp.image.tag is required when mcp.enabled is true; the chart appVersion tracks argo-watcher, not the MCP server" }}
+{{- end }}
+{{- .Values.mcp.image.tag }}
+{{- end }}
+
+{{- define "argo-watcher.mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argo-watcher.mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "argo-watcher.mcp.labels" -}}
+helm.sh/chart: {{ include "argo-watcher.chart" . }}
+{{ include "argo-watcher.mcp.selectorLabels" . }}
+app.kubernetes.io/version: {{ include "argo-watcher.mcp.tag" . | trunc 63 | trimSuffix "-" | quote }}
+app.kubernetes.io/component: mcp
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+In-cluster URL of the argo-watcher API the MCP server reads from.
+*/}}
+{{- define "argo-watcher.mcp.upstreamUrl" -}}
+{{- printf "http://%s:%v" (include "argo-watcher.fullname" .) .Values.service.port }}
+{{- end }}
+
+{{- define "argo-watcher.mcp.serviceAccountName" -}}
+{{- if .Values.mcp.serviceAccount.create }}
+{{- default (include "argo-watcher.mcp.fullname" .) .Values.mcp.serviceAccount.name }}
+{{- else }}
+{{- required "mcp.serviceAccount.name is required when mcp.serviceAccount.create is false" .Values.mcp.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
 {{- define "argo-watcher.scheduleToString" -}}
 {{- $scheduleList := .Values.scheduledLockdown -}}
 {{- $finalString := "" -}}

--- a/charts/argo-watcher/templates/_helpers.tpl
+++ b/charts/argo-watcher/templates/_helpers.tpl
@@ -65,18 +65,27 @@ Create the name of the service account to use
 Name of the MCP server workload. Kept distinct from the argo-watcher name so the
 argo-watcher selectors, NetworkPolicies and PodMonitor never match MCP pods.
 
-The suffix is appended after truncating the base to 59 characters, not before:
-truncating the joined string would collapse any 63-character name back onto the
-argo-watcher name, silently giving both workloads the same selector labels. The
-one input this does not separate is a 63-character name that already ends in
-"-mcp".
+Truncation happens before the suffix is appended, and the result is compared
+against the base rather than length-checked: a base of 62 or 63 characters that
+already ends in "-mcp" reduces back to itself, which would hand both workloads
+the same selector labels.
 */}}
 {{- define "argo-watcher.mcp.name" -}}
-{{- printf "%s-mcp" (include "argo-watcher.name" . | trunc 59 | trimSuffix "-") }}
+{{- $base := include "argo-watcher.name" . }}
+{{- $name := printf "%s-mcp" ($base | trunc 59 | trimSuffix "-") }}
+{{- if eq $name $base }}
+{{- fail (printf "nameOverride %q yields an MCP workload name identical to argo-watcher's; shorten it to at most 61 characters or drop its \"-mcp\" suffix" $base) }}
+{{- end }}
+{{- $name }}
 {{- end }}
 
 {{- define "argo-watcher.mcp.fullname" -}}
-{{- printf "%s-mcp" (include "argo-watcher.fullname" . | trunc 59 | trimSuffix "-") }}
+{{- $base := include "argo-watcher.fullname" . }}
+{{- $name := printf "%s-mcp" ($base | trunc 59 | trimSuffix "-") }}
+{{- if eq $name $base }}
+{{- fail (printf "fullname %q yields an MCP object name identical to argo-watcher's; shorten the release name, nameOverride or fullnameOverride to at most 61 characters" $base) }}
+{{- end }}
+{{- $name }}
 {{- end }}
 
 {{/*

--- a/charts/argo-watcher/templates/mcp-deployment.yaml
+++ b/charts/argo-watcher/templates/mcp-deployment.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  revisionHistoryLimit: {{ .Values.mcp.revisionHistory }}
+  selector:
+    matchLabels:
+      {{- include "argo-watcher.mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.mcp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "argo-watcher.mcp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "argo-watcher.mcp.serviceAccountName" . }}
+      # Enforced on the pod as well as the ServiceAccount so a pre-created
+      # account cannot mount a token into a workload that never calls the API.
+      automountServiceAccountToken: {{ .Values.mcp.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.mcp.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "argo-watcher.mcp.name" . }}
+          securityContext:
+            {{- toYaml .Values.mcp.securityContext | nindent 12 }}
+          image: "{{ .Values.mcp.image.repository }}:{{ include "argo-watcher.mcp.tag" . }}"
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mcp.service.containerPort }}
+              protocol: TCP
+          env:
+            - name: ARGO_WATCHER_URL
+              value: {{ include "argo-watcher.mcp.upstreamUrl" . | quote }}
+            - name: TRANSPORT_MODE
+              value: "http"
+            - name: HTTP_LISTEN_ADDR
+              value: {{ printf ":%v" .Values.mcp.service.containerPort | quote }}
+            - name: REQUEST_TIMEOUT
+              value: {{ .Values.mcp.requestTimeout | quote }}
+            {{- with .Values.mcp.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.mcp.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.mcp.livenessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.mcp.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mcp.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.mcp.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.mcp.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.mcp.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.mcp.readinessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.mcp.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mcp.readinessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.mcp.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.mcp.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.mcp.resources | nindent 12 }}
+      {{- with .Values.mcp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcp.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/argo-watcher/templates/mcp-deployment.yaml
+++ b/charts/argo-watcher/templates/mcp-deployment.yaml
@@ -25,8 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-watcher.mcp.serviceAccountName" . }}
-      # Enforced on the pod as well as the ServiceAccount so a pre-created
-      # account cannot mount a token into a workload that never calls the API.
+      # Also set here so a pre-created ServiceAccount cannot mount a token.
       automountServiceAccountToken: {{ .Values.mcp.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.mcp.podSecurityContext | nindent 8 }}

--- a/charts/argo-watcher/templates/mcp-ingress.yaml
+++ b/charts/argo-watcher/templates/mcp-ingress.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.mcp.enabled .Values.mcp.ingress.enabled -}}
+{{- $fullName := include "argo-watcher.mcp.fullname" . -}}
+{{- $svcPort := .Values.mcp.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+  {{- with .Values.mcp.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.mcp.ingress.className }}
+  ingressClassName: {{ .Values.mcp.ingress.className }}
+  {{- end }}
+  {{- if .Values.mcp.ingress.tls }}
+  tls:
+    {{- range .Values.mcp.ingress.tls }}
+    - hosts:
+       {{- range .hosts }}
+        - {{ . | quote }}
+       {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.mcp.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/argo-watcher/templates/mcp-network-policies.yaml
+++ b/charts/argo-watcher/templates/mcp-network-policies.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.mcp.enabled .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}-deny-ingress
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "argo-watcher.mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}-allow-self-namespace
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "argo-watcher.mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+{{- if .Values.mcp.networkPolicies.additionalRules }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}-additional-ingress
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "argo-watcher.mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- with .Values.mcp.networkPolicies.additionalRules }}
+    - from:
+        {{- toYaml . | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.mcp.service.containerPort }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/argo-watcher/templates/mcp-podmonitor.yaml
+++ b/charts/argo-watcher/templates/mcp-podmonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.mcp.enabled .Values.mcp.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}-metrics
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+    {{- with .Values.mcp.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "argo-watcher.mcp.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      {{- with .Values.mcp.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.mcp.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/argo-watcher/templates/mcp-service.yaml
+++ b/charts/argo-watcher/templates/mcp-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argo-watcher.mcp.fullname" . }}
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: {{ .Values.mcp.service.containerPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "argo-watcher.mcp.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/argo-watcher/templates/mcp-serviceaccount.yaml
+++ b/charts/argo-watcher/templates/mcp-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.mcp.enabled .Values.mcp.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argo-watcher.mcp.serviceAccountName" . }}
+  labels:
+    {{- include "argo-watcher.mcp.labels" . | nindent 4 }}
+  {{- with .Values.mcp.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.mcp.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/argo-watcher/tests/mcp-deployment_test.yaml
+++ b/charts/argo-watcher/tests/mcp-deployment_test.yaml
@@ -261,6 +261,42 @@ tests:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg
 
+  - it: should refuse a name override that collides with the argo-watcher name
+    set:
+      nameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefffffffff-mcp
+      mcp:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: yields an MCP workload name identical to argo-watcher's
+
+  - it: should refuse a shorter colliding name override that truncation reduces
+    set:
+      nameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffff-mcp
+      mcp:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: yields an MCP workload name identical to argo-watcher's
+
+  - it: should ignore a colliding name override while mcp is disabled
+    set:
+      nameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefffffffff-mcp
+      mcp:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should refuse a fullname override that collides with the argo-watcher name
+    set:
+      fullnameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefffffffff-mcp
+      mcp:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: yields an MCP object name identical to argo-watcher's
+
   - it: should keep object names within the dns label limit
     set:
       fullnameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg

--- a/charts/argo-watcher/tests/mcp-deployment_test.yaml
+++ b/charts/argo-watcher/tests/mcp-deployment_test.yaml
@@ -1,0 +1,399 @@
+suite: test mcp deployment
+templates:
+  - templates/mcp-deployment.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be created if disabled
+    set:
+      mcp:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a deployment when enabled
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isAPIVersion:
+          of: apps/v1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: argo-watcher-mcp
+
+  - it: should carry its own name label so the argo-watcher selectors do not match it
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: argo-watcher-mcp
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: v0.3.0
+
+  - it: should point at the argo-watcher service and speak http
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARGO_WATCHER_URL
+            value: http://RELEASE-NAME-argo-watcher:80
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRANSPORT_MODE
+            value: http
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_LISTEN_ADDR
+            value: ":8000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUEST_TIMEOUT
+            value: 15s
+
+  - it: should follow the argo-watcher service port and fullnameOverride
+    set:
+      fullnameOverride: watcher
+      service:
+        port: 8080
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: watcher-mcp
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ARGO_WATCHER_URL
+            value: http://watcher:8080
+
+  - it: should bind the listen address to the configured container port
+    set:
+      mcp:
+        enabled: true
+        service:
+          containerPort: 9000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_LISTEN_ADDR
+            value: ":9000"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+
+  - it: should use the pinned image tag
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/shini4i/argo-watcher-mcp:v0.3.0
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should allow overriding the image
+    set:
+      mcp:
+        enabled: true
+        image:
+          repository: example.com/argo-watcher-mcp
+          tag: v9.9.9
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example.com/argo-watcher-mcp:v9.9.9
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should fail when the image tag is emptied
+    set:
+      mcp:
+        enabled: true
+        image:
+          tag: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: mcp.image.tag is required when mcp.enabled is true; the chart appVersion tracks argo-watcher, not the MCP server
+
+  - it: should probe healthz on both probes by default
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+
+  - it: should allow gating readiness on argo-watcher reachability
+    set:
+      mcp:
+        enabled: true
+        readinessProbe:
+          path: /readyz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+
+  - it: should allow disabling probes
+    set:
+      mcp:
+        enabled: true
+        livenessProbe:
+          enabled: false
+        readinessProbe:
+          enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should run as an unprivileged user with a read-only root filesystem
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: should use its own service account
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-argo-watcher-mcp
+
+  - it: should use a pre-created service account when creation is disabled
+    set:
+      mcp:
+        enabled: true
+        serviceAccount:
+          create: false
+          name: existing-mcp-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-mcp-sa
+
+  - it: should fail when service account creation is disabled without a name
+    set:
+      mcp:
+        enabled: true
+        serviceAccount:
+          create: false
+    asserts:
+      - failedTemplate:
+          errorMessage: mcp.serviceAccount.name is required when mcp.serviceAccount.create is false
+
+  - it: should refuse a token on the pod even with a pre-created service account
+    set:
+      mcp:
+        enabled: true
+        serviceAccount:
+          create: false
+          name: existing-mcp-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should reserve room for the mcp suffix instead of truncating it away
+    set:
+      nameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg
+      mcp:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          pattern: ^a{10}b{10}c{10}d{10}e{10}f{9}-mcp$
+      - notEqual:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg
+
+  - it: should keep object names within the dns label limit
+    set:
+      fullnameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg
+      mcp:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: ^.{1,63}$
+      - matchRegex:
+          path: metadata.name
+          pattern: -mcp$
+
+  - it: should keep the version label a valid kubernetes label value
+    set:
+      mcp:
+        enabled: true
+        image:
+          tag: v0.3.0-aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggg
+    asserts:
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/version"]
+          pattern: ^.{1,63}$
+
+  - it: should append extra environment variables
+    set:
+      mcp:
+        enabled: true
+        extraEnvs:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: otel-collector:4317
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "true"
+          - name: FROM_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: secret-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: otel-collector:4317
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: secret-key
+
+  - it: should keep the pod and container security contexts separate
+    set:
+      mcp:
+        enabled: true
+        podSecurityContext:
+          fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65532
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.fsGroup
+
+  - it: should pass scheduling and pod level values through
+    set:
+      mcp:
+        enabled: true
+        replicaCount: 3
+        revisionHistory: 5
+        podAnnotations:
+          example.com/annotation: value
+        nodeSelector:
+          disktype: ssd
+        tolerations:
+          - key: example
+            operator: Exists
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: example
+                      operator: Exists
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+        resources:
+          limits:
+            cpu: 100m
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+      - equal:
+          path: spec.template.metadata.annotations["example.com/annotation"]
+          value: value
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: example
+      - isNotNull:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+
+  - it: should honour image pull secrets
+    set:
+      imagePullSecrets:
+        - name: regcred
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: regcred

--- a/charts/argo-watcher/tests/mcp-ingress_test.yaml
+++ b/charts/argo-watcher/tests/mcp-ingress_test.yaml
@@ -1,0 +1,143 @@
+suite: test mcp ingress
+templates:
+  - templates/mcp-ingress.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be created when mcp itself is disabled
+    set:
+      mcp:
+        enabled: false
+        ingress:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should route to the mcp service
+    set:
+      mcp:
+        enabled: true
+        ingress:
+          enabled: true
+          className: nginx
+          annotations:
+            nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy.example.com/oauth2/auth
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+                  pathType: Prefix
+          tls:
+            - hosts:
+                - mcp.example.com
+                - mcp-alt.example.com
+              secretName: mcp-example-com-tls
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy.example.com/oauth2/auth
+      - equal:
+          path: spec.rules[0].host
+          value: mcp.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-argo-watcher-mcp
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80
+      - equal:
+          path: spec.tls[0].secretName
+          value: mcp-example-com-tls
+      - equal:
+          path: spec.tls[0].hosts
+          value:
+            - mcp.example.com
+            - mcp-alt.example.com
+
+  - it: should render every host and path
+    set:
+      mcp:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+                  pathType: Prefix
+                - path: /mcp
+                  pathType: Exact
+            - host: mcp-alt.example.com
+              paths:
+                - path: /
+                  pathType: Prefix
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 2
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /mcp
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Exact
+      - equal:
+          path: spec.rules[1].host
+          value: mcp-alt.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: RELEASE-NAME-argo-watcher-mcp
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 80
+
+  - it: should follow the mcp service port
+    set:
+      mcp:
+        enabled: true
+        service:
+          port: 8080
+        ingress:
+          enabled: true
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+                  pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+
+  - it: should default the path type
+    set:
+      mcp:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix

--- a/charts/argo-watcher/tests/mcp-network-policies_test.yaml
+++ b/charts/argo-watcher/tests/mcp-network-policies_test.yaml
@@ -1,0 +1,112 @@
+suite: test mcp network policies
+templates:
+  - templates/mcp-network-policies.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be created when mcp is disabled
+    set:
+      networkPolicies:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be created when network policies are disabled
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the default policies for the mcp pods only
+    set:
+      networkPolicies:
+        enabled: true
+      mcp:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp-deny-ingress
+      - documentIndex: 0
+        equal:
+          path: spec.podSelector.matchLabels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: argo-watcher-mcp
+      - documentIndex: 0
+        contains:
+          path: spec.policyTypes
+          content: Ingress
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp-allow-self-namespace
+      - documentIndex: 1
+        equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: NAMESPACE
+
+  - it: should scope additional rules to the mcp port only
+    set:
+      networkPolicies:
+        enabled: true
+      mcp:
+        enabled: true
+        service:
+          containerPort: 9000
+        networkPolicies:
+          additionalRules:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: ingress-nginx
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp-additional-ingress
+      - documentIndex: 2
+        equal:
+          path: spec.podSelector.matchLabels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: argo-watcher-mcp
+      - documentIndex: 2
+        equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: ingress-nginx
+      - documentIndex: 2
+        equal:
+          path: spec.ingress[0].ports[0].port
+          value: 9000
+
+  - it: should not widen the argo-watcher policies when the mcp rules are set
+    set:
+      networkPolicies:
+        enabled: true
+        additionalRules:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: argocd
+      mcp:
+        enabled: true
+        networkPolicies:
+          additionalRules:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: ingress-nginx
+    asserts:
+      - documentIndex: 2
+        notEqual:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: argocd

--- a/charts/argo-watcher/tests/mcp-podmonitor_test.yaml
+++ b/charts/argo-watcher/tests/mcp-podmonitor_test.yaml
@@ -1,0 +1,65 @@
+suite: test mcp podmonitor
+templates:
+  - templates/mcp-podmonitor.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not be created when mcp itself is disabled
+    set:
+      mcp:
+        enabled: false
+        podMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should scrape the mcp pods
+    set:
+      mcp:
+        enabled: true
+        podMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp-metrics
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: argo-watcher-mcp
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: http
+      - equal:
+          path: spec.podMetricsEndpoints[0].path
+          value: /metrics
+
+  - it: should pass optional scrape settings and labels
+    set:
+      mcp:
+        enabled: true
+        podMonitor:
+          enabled: true
+          interval: 30s
+          scrapeTimeout: 5s
+          labels:
+            release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scrapeTimeout
+          value: 5s
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack

--- a/charts/argo-watcher/tests/mcp-service_test.yaml
+++ b/charts/argo-watcher/tests/mcp-service_test.yaml
@@ -1,13 +1,16 @@
-suite: test service
+suite: test mcp service
 templates:
-  - templates/service.yaml
+  - templates/mcp-service.yaml
 tests:
-  - it: should be enabled by default
+  - it: should be disabled by default
     asserts:
       - hasDocuments:
-          count: 1
+          count: 0
 
-  - it: should pass default values
+  - it: should pass default values when enabled
+    set:
+      mcp:
+        enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -15,6 +18,9 @@ tests:
           of: v1
       - isKind:
           of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp
       - equal:
           path: spec.type
           value: ClusterIP
@@ -29,52 +35,50 @@ tests:
           value: TCP
       - equal:
           path: spec.ports[0].targetPort
-          value: 8080
-      - equal:
-          path: spec.selector
-          value:
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: argo-watcher
+          value: 8000
 
-  - it: should pass custom port values
-    set:
-      service:
-        type: ClusterIP
-        port: 8080
-        containerPort: 8081
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: spec.type
-          value: ClusterIP
-      - equal:
-          path: spec.ports[0].port
-          value: 8080
-      - equal:
-          path: spec.ports[0].protocol
-          value: TCP
-      - equal:
-          path: spec.ports[0].targetPort
-          value: 8081
-
-  - it: should pass custom release name
-    release:
-      name: example
-    asserts:
-      - equal:
-          path: spec.selector
-          value:
-            app.kubernetes.io/instance: example
-            app.kubernetes.io/name: argo-watcher
-
-  - it: should not select the mcp pods when the mcp server is enabled
+  - it: should only select the mcp pods
     set:
       mcp:
         enabled: true
     asserts:
-      - hasDocuments:
-          count: 1
       - equal:
-          path: spec.selector["app.kubernetes.io/name"]
-          value: argo-watcher
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: argo-watcher-mcp
+
+  - it: should pass custom port values
+    set:
+      mcp:
+        enabled: true
+        service:
+          type: NodePort
+          port: 8080
+          containerPort: 9000
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9000
+
+  - it: should pass custom release name
+    release:
+      name: example
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: example-argo-watcher-mcp
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: example
+            app.kubernetes.io/name: argo-watcher-mcp

--- a/charts/argo-watcher/tests/mcp-serviceaccount_test.yaml
+++ b/charts/argo-watcher/tests/mcp-serviceaccount_test.yaml
@@ -1,0 +1,54 @@
+suite: test mcp service account
+templates:
+  - templates/mcp-serviceaccount.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be created when mcp is enabled
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-argo-watcher-mcp
+
+  - it: should not automount a token, the mcp server never calls the kubernetes api
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should not be created when a pre-existing account is used
+    set:
+      mcp:
+        enabled: true
+        serviceAccount:
+          create: false
+          name: existing-mcp-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should pass annotations
+    set:
+      mcp:
+        enabled: true
+        serviceAccount:
+          annotations:
+            example.com/annotation: value
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            example.com/annotation: value

--- a/charts/argo-watcher/tests/notes_test.yaml
+++ b/charts/argo-watcher/tests/notes_test.yaml
@@ -1,0 +1,58 @@
+suite: test notes
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: should not mention the mcp server by default
+    asserts:
+      - notMatchRegexRaw:
+          pattern: MCP
+
+  - it: should explain how to reach the mcp server
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - matchRegexRaw:
+          pattern: port-forward svc/RELEASE-NAME-argo-watcher-mcp 8000:80
+
+  - it: should not warn about exposure while the mcp ingress is disabled
+    set:
+      mcp:
+        enabled: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: WARNING
+
+  - it: should warn that the exposed mcp endpoint is unauthenticated
+    set:
+      mcp:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+    asserts:
+      - matchRegexRaw:
+          pattern: performs NO\n  authentication or authorization
+      - matchRegexRaw:
+          pattern: http://mcp.example.com/
+
+  - it: should print an https url when the mcp ingress terminates tls
+    set:
+      mcp:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - host: mcp.example.com
+              paths:
+                - path: /
+          tls:
+            - hosts:
+                - mcp.example.com
+              secretName: mcp-example-com-tls
+    asserts:
+      - matchRegexRaw:
+          pattern: https://mcp.example.com/

--- a/charts/argo-watcher/tests/podmonitor_test.yaml
+++ b/charts/argo-watcher/tests/podmonitor_test.yaml
@@ -61,3 +61,18 @@ tests:
       - equal:
           path: spec.podMetricsEndpoints[0].scrapeTimeout
           value: 10
+
+  - it: should not scrape the mcp pods when the mcp server is enabled
+    set:
+      podMonitor:
+        enabled: true
+      mcp:
+        enabled: true
+        podMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: argo-watcher

--- a/charts/argo-watcher/values.schema.json
+++ b/charts/argo-watcher/values.schema.json
@@ -228,6 +228,113 @@
         "maxUnavailable": { "type": ["integer", "string"] }
       },
       "required": ["enabled"]
+    },
+    "mcp": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "revisionHistory": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": ["string", "number"] }
+          },
+          "required": ["repository"]
+        },
+        "requestTimeout": { "type": "string" },
+        "livenessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "periodSeconds": { "type": "integer", "minimum": 1 },
+            "timeoutSeconds": { "type": "integer", "minimum": 1 },
+            "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+            "failureThreshold": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["enabled"]
+        },
+        "readinessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "periodSeconds": { "type": "integer", "minimum": 1 },
+            "timeoutSeconds": { "type": "integer", "minimum": 1 },
+            "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+            "failureThreshold": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["enabled"]
+        },
+        "extraEnvs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" }
+            },
+            "required": ["name"]
+          }
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" },
+            "annotations": { "type": "object" },
+            "name": { "type": "string" },
+            "automountServiceAccountToken": { "type": "boolean" }
+          },
+          "required": ["create"]
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          },
+          "required": ["type", "port", "containerPort"]
+        },
+        "ingress": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "className": { "type": "string" },
+            "annotations": { "type": "object" },
+            "hosts": { "type": "array" },
+            "tls": { "type": "array" }
+          },
+          "required": ["enabled"]
+        },
+        "networkPolicies": {
+          "type": "object",
+          "properties": {
+            "additionalRules": { "type": "array" }
+          }
+        },
+        "podMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": ["string", "number"] },
+            "scrapeTimeout": { "type": ["string", "number"] },
+            "labels": { "type": "object" }
+          },
+          "required": ["enabled"]
+        },
+        "podAnnotations": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "securityContext": { "type": "object" },
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "topologySpreadConstraints": { "type": "array" }
+      },
+      "required": ["enabled"]
     }
   },
   "required": ["replicaCount", "image", "argo"]

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -283,10 +283,9 @@ mcp:
     initialDelaySeconds: 5
     failureThreshold: 3
 
-  # -- Readiness probe configuration. Defaults to /healthz so the server keeps
-  # serving while argo-watcher is down, which is what lets its get_reachability
-  # tool report the outage. Set path to /readyz to gate readiness on argo-watcher
-  # being reachable instead, accepting that the endpoint disappears with it.
+  # -- Readiness probe configuration. /healthz keeps the server serving while
+  # argo-watcher is down, so its get_reachability tool can report the outage;
+  # /readyz gates readiness on argo-watcher instead, and drops out with it.
   readinessProbe:
     enabled: true
     path: /healthz
@@ -317,13 +316,10 @@ mcp:
     port: 80
     containerPort: 8000
 
-  # Ingress for the MCP endpoint. WARNING: argo-watcher-mcp performs no
-  # authentication or authorization; anything that can reach this Ingress can
-  # read the full deployment history and instance configuration. Only enable it
-  # with an authenticating proxy in front — see the chart README.
   ingress:
-    # -- Expose the MCP endpoint via Ingress. The endpoint is UNAUTHENTICATED;
-    # put an authenticating proxy in front of it.
+    # -- Expose the MCP endpoint via Ingress. Anything that can reach it can read
+    # the full deployment history and instance configuration, so put an
+    # authenticating proxy in front — see "Exposing the MCP server" in the README.
     enabled: false
     className: ""
     annotations: {}

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -249,3 +249,133 @@ podDisruptionBudget:
   enabled: false
   # minAvailable: 1
   # maxUnavailable: 1
+
+# Optional argo-watcher-mcp deployment (https://github.com/shini4i/argo-watcher-mcp),
+# which exposes argo-watcher's read-only API as MCP tools for AI agents. It runs as
+# its own workload, not as a sidecar, so it can be updated and exposed without
+# restarting argo-watcher.
+#
+# The MCP endpoint performs NO authentication or authorization of its own. Read
+# "Exposing the MCP server" in the chart README before exposing it.
+mcp:
+  # -- Deploy the MCP server alongside argo-watcher
+  enabled: false
+  replicaCount: 1
+  revisionHistory: 1
+
+  image:
+    repository: ghcr.io/shini4i/argo-watcher-mcp
+    pullPolicy: IfNotPresent
+    # -- MCP server image tag. Pinned here rather than derived from the chart
+    # appVersion, which tracks argo-watcher itself. Required when mcp is enabled.
+    tag: "v0.3.0"
+
+  # -- How long the MCP server waits for an argo-watcher API response
+  requestTimeout: 15s
+
+  # -- Liveness probe configuration. /healthz reports only whether the MCP
+  # process is up; it does not depend on argo-watcher.
+  livenessProbe:
+    enabled: true
+    path: /healthz
+    periodSeconds: 30
+    timeoutSeconds: 5
+    initialDelaySeconds: 5
+    failureThreshold: 3
+
+  # -- Readiness probe configuration. Defaults to /healthz so the server keeps
+  # serving while argo-watcher is down, which is what lets its get_reachability
+  # tool report the outage. Set path to /readyz to gate readiness on argo-watcher
+  # being reachable instead, accepting that the endpoint disappears with it.
+  readinessProbe:
+    enabled: true
+    path: /healthz
+    periodSeconds: 10
+    timeoutSeconds: 3
+    initialDelaySeconds: 3
+    failureThreshold: 3
+
+  # -- Additional environment variables for the MCP container, e.g. the OTEL_*
+  # settings (supports both value and valueFrom)
+  extraEnvs: []
+  #  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+  #    value: "otel-collector.observability:4317"
+
+  serviceAccount:
+    # -- Specifies whether a service account should be created
+    create: true
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- The name of the service account to use. Required when create is false.
+    name: ""
+    # -- Whether to automount the service account token. The MCP server never
+    # calls the Kubernetes API.
+    automountServiceAccountToken: false
+
+  service:
+    type: ClusterIP
+    port: 80
+    containerPort: 8000
+
+  # Ingress for the MCP endpoint. WARNING: argo-watcher-mcp performs no
+  # authentication or authorization; anything that can reach this Ingress can
+  # read the full deployment history and instance configuration. Only enable it
+  # with an authenticating proxy in front — see the chart README.
+  ingress:
+    # -- Expose the MCP endpoint via Ingress. The endpoint is UNAUTHENTICATED;
+    # put an authenticating proxy in front of it.
+    enabled: false
+    className: ""
+    annotations: {}
+      # nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.example.com/oauth2/auth"
+      # nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.example.com/oauth2/start?rd=$escaped_request_uri"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  networkPolicies:
+    # -- Additional ingress rules granting access to the MCP container port.
+    # Created when networkPolicies.enabled is true; kept separate from
+    # networkPolicies.additionalRules so opening the MCP endpoint to a wider
+    # audience cannot also open the argo-watcher API.
+    additionalRules: []
+    # - namespaceSelector:
+    #     matchLabels:
+    #       kubernetes.io/metadata.name: "ingress-nginx"
+
+  podMonitor:
+    enabled: false
+    # interval: 30s
+    # scrapeTimeout: 5s
+    labels: {}
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65532
+    allowPrivilegeEscalation: false
+
+  resources: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  topologySpreadConstraints: []


### PR DESCRIPTION
Deploy shini4i/argo-watcher-mcp behind mcp.enabled (default false) as its own workload rather than a sidecar, so its image and configuration can change without rolling the argo-watcher StatefulSet and dropping in-memory task history.

MCP pods carry their own app.kubernetes.io/name, which keeps the argo-watcher Service, PodMonitor and NetworkPolicy selectors from matching them, and mcp.networkPolicies.additionalRules is separate from networkPolicies.additionalRules so widening access to the MCP endpoint cannot widen access to the argo-watcher API.

The endpoint performs no authentication or authorization of its own. The chart README, values.yaml and NOTES.txt state that and cover how to expose it, from port-forward through Ingress behind an authenticating proxy.