### PR TITLE
feat(argo-watcher): point probes at livez and readyz

### DIFF
--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -20,6 +20,18 @@ A Helm chart for deploying argo-watcher
 
 Kubernetes: `>=1.21.0-0`
 
+## Probes
+
+The liveness probe targets `/livez` and the readiness probe targets `/readyz`. Do
+not swap them: a liveness failure restarts the container, and a restart cannot
+reach a database that is down — see the `livenessProbe` and `readinessProbe`
+entries in the values table for the full reasoning.
+
+Both endpoints require an argo-watcher release that implements the liveness and
+readiness split, which replaced `/healthz`. If your `image.tag` predates it, set
+`livenessProbe.path`, `readinessProbe.path` and `startupProbe.path` back to
+`/healthz`.
+
 ## MCP server
 
 Setting `mcp.enabled: true` deploys [argo-watcher-mcp](https://github.com/shini4i/argo-watcher-mcp),
@@ -166,7 +178,7 @@ PodMonitor has the same property.
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
-| livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"path":"/healthz","periodSeconds":30,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"path":"/livez","periodSeconds":30,"timeoutSeconds":5}` | Liveness probe configuration. /livez checks no dependency, so a state backend outage marks pods unready instead of restarting them; do not point this at /readyz. |
 | logLevel | string | `"info"` |  |
 | mcp.affinity | object | `{}` |  |
 | mcp.enabled | bool | `false` | Deploy the MCP server alongside argo-watcher |
@@ -246,7 +258,7 @@ PodMonitor has the same property.
 | postgres.secretKey | string | `""` | Support for an optional key override (this specific key would be exposed to DB_PASSWORD) |
 | postgres.secretName | string | `""` | Pre-created secret with DB_PASSWORD variable |
 | postgres.user | string | `""` |  |
-| readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"path":"/healthz","periodSeconds":10,"timeoutSeconds":3}` | Readiness probe configuration |
+| readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":3,"path":"/readyz","periodSeconds":10,"timeoutSeconds":3}` | Readiness probe configuration. /readyz reports down while the pod is shutting down and while the state backend is unreachable. ArgoCD reachability is excluded, so an ArgoCD outage keeps the API and Web UI serving. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | revisionHistory | int | `1` |  |
@@ -264,7 +276,7 @@ PodMonitor has the same property.
 | serviceAccount.automountServiceAccountToken | bool | `true` | Whether to automount the service account token |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| startupProbe | object | `{"enabled":false,"failureThreshold":30,"path":"/healthz","periodSeconds":5,"timeoutSeconds":3}` | Startup probe configuration |
+| startupProbe | object | `{"enabled":false,"failureThreshold":30,"path":"/livez","periodSeconds":5,"timeoutSeconds":3}` | Startup probe configuration. Disabled because argo-watcher binds its listener only after its config, ArgoCD client and state backend are initialised, and exits rather than starting degraded, so there is no slow-start window for a startup probe to cover. |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |
 | updater | object | `{"commitAuthor":"argo-watcher","commitEmail":"argo-watcher@example.com","extraKnownHosts":[],"knownHostsConfigMap":"","knownHostsKey":"ssh_known_hosts","sshKey":"sshPrivateKey","sshSecretName":""}` | Configuration for argo image updater logic replacement (optional) |

--- a/charts/argo-watcher/README.md.gotmpl
+++ b/charts/argo-watcher/README.md.gotmpl
@@ -14,6 +14,18 @@
 
 {{ template "chart.requirementsSection" . }}
 
+## Probes
+
+The liveness probe targets `/livez` and the readiness probe targets `/readyz`. Do
+not swap them: a liveness failure restarts the container, and a restart cannot
+reach a database that is down — see the `livenessProbe` and `readinessProbe`
+entries in the values table for the full reasoning.
+
+Both endpoints require an argo-watcher release that implements the liveness and
+readiness split, which replaced `/healthz`. If your `image.tag` predates it, set
+`livenessProbe.path`, `readinessProbe.path` and `startupProbe.path` back to
+`/healthz`.
+
 ## MCP server
 
 Setting `mcp.enabled: true` deploys [argo-watcher-mcp](https://github.com/shini4i/argo-watcher-mcp),

--- a/charts/argo-watcher/tests/statefulset_test.yaml
+++ b/charts/argo-watcher/tests/statefulset_test.yaml
@@ -544,6 +544,18 @@ tests:
       - failedTemplate:
           errorMessage: "oidc.clientId is required when oidc.enabled is true"
 
+  # Liveness must not depend on the state backend: a restart cannot bring a
+  # database back, so probing it for liveness turns an outage into a
+  # CrashLoopBackoff while the pods can still serve task history.
+  - it: should probe livez for liveness and readyz for readiness by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+
   - it: should render separate liveness and readiness probes with different defaults
     asserts:
       - equal:
@@ -564,18 +576,27 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
+  - it: should probe livez when the startup probe is enabled without overrides
+    set:
+      startupProbe:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /livez
+
   - it: should render startup probe when enabled
     set:
       startupProbe:
         enabled: true
-        path: /healthz
+        path: /livez
         periodSeconds: 5
         timeoutSeconds: 3
         failureThreshold: 30
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
-          value: /healthz
+          value: /livez
       - equal:
           path: spec.template.spec.containers[0].startupProbe.periodSeconds
           value: 5

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -12,28 +12,35 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# -- Liveness probe configuration
+# -- Liveness probe configuration. /livez checks no dependency, so a state
+# backend outage marks pods unready instead of restarting them; do not point
+# this at /readyz.
 livenessProbe:
   enabled: true
-  path: /healthz
+  path: /livez
   periodSeconds: 30
   timeoutSeconds: 5
   initialDelaySeconds: 5
   failureThreshold: 3
 
-# -- Readiness probe configuration
+# -- Readiness probe configuration. /readyz reports down while the pod is
+# shutting down and while the state backend is unreachable. ArgoCD reachability
+# is excluded, so an ArgoCD outage keeps the API and Web UI serving.
 readinessProbe:
   enabled: true
-  path: /healthz
+  path: /readyz
   periodSeconds: 10
   timeoutSeconds: 3
   initialDelaySeconds: 3
   failureThreshold: 3
 
-# -- Startup probe configuration
+# -- Startup probe configuration. Disabled because argo-watcher binds its
+# listener only after its config, ArgoCD client and state backend are
+# initialised, and exits rather than starting degraded, so there is no slow-start
+# window for a startup probe to cover.
 startupProbe:
   enabled: false
-  path: /healthz
+  path: /livez
   periodSeconds: 5
   timeoutSeconds: 3
   failureThreshold: 30


### PR DESCRIPTION
Upstream replaced GET /healthz with GET /livez, which checks no dependency, and GET /readyz, which fails while the pod drains and while the state backend is unreachable. Liveness now targets /livez, so a state backend outage marks pods unready instead of restarting them.

The chart appVersion still names a release that serves /healthz only, so this must not be released until appVersion names the release carrying the split.

To be merged after https://github.com/shini4i/argo-watcher/pull/535