### PR TITLE
fix(app): repair job template rendering and widen its configuration

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,17 +2,21 @@ apiVersion: v2
 name: app
 description: A Helm chart for a simple app deployment
 type: application
-version: 0.2.1
+version: 0.3.0
 
 annotations:
   artifacthub.io/signKey: |
     fingerprint: FF1E9948F6234DC6D70AB47BF509F29B63C1DC2B
     url: https://shini4i.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: fixed
+      description: job annotations are no longer rendered outside of the metadata block
     - kind: changed
-      description: got rid of heavily outdated kubernetes support in Ingress
+      description: 'job.annotations now defaults to {}; set "helm.sh/hook" explicitly to keep the pre-upgrade hook, otherwise delete the leftover hook-created job before upgrading'
     - kind: added
-      description: support for specifying additional services in Ingress
+      description: job now carries the common chart labels and supports labels, podLabels and podAnnotations
+    - kind: added
+      description: job support for args, resources, volumes, volumeMounts, ttlSecondsAfterFinished and activeDeadlineSeconds
 
 maintainers:
   - name: Vadim Gedz

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -64,7 +64,7 @@ A Helm chart for a simple app deployment
 | job.labels | object | `{}` | Labels to add to the job on top of the common chart labels |
 | job.nodeSelector | object | `{}` | NodeSelector to use for the job pod |
 | job.podAnnotations | object | `{}` | Annotations to add to the job pod |
-| job.podLabels | object | `{}` | Labels to add to the job pod on top of instance, managed-by and component |
+| job.podLabels | object | `{}` | Labels to add to the job pod on top of instance, managed-by and component. app.kubernetes.io/name is ignored: it would enrol job pods as Service endpoints |
 | job.podSecurityContext | object | `{}` | podSecurityContext to use for the job pod |
 | job.resources | object | `{}` | Resources to request for the job container |
 | job.restartPolicy | string | `"Never"` |  |

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for a simple app deployment
 
@@ -48,11 +48,12 @@ A Helm chart for a simple app deployment
 | ingressRoute | object | `{"annotations":{},"enabled":false,"entryPoint":"websecure","exposedPort":80,"host":"example.com","labels":{},"tlsSecret":"example-com-tls"}` | Traefik v2 ingressRoute definition |
 | ingressRoute.exposedPort | int | `80` | Port to use with ingressRoute |
 | initContainers | list | `[]` | Raw yaml definition of init containers |
+| job.activeDeadlineSeconds | string | `nil` | Seconds a job may run before it is terminated and marked failed |
 | job.affinity | object | `{}` | Affinity to use for the job pod |
-| job.annotations."helm.sh/hook" | string | `"pre-upgrade"` |  |
+| job.annotations | object | `{}` | Annotations to add to the job. Set "helm.sh/hook" here to run the job as a Helm hook |
+| job.args | list | `[]` | A job container args |
 | job.backoffLimit | int | `1` |  |
-| job.command[0] | string | `"curl"` |  |
-| job.command[1] | string | `"https://ifconfig.me"` |  |
+| job.command | list | `["curl","https://ifconfig.me"]` | A job container command override |
 | job.enabled | bool | `false` |  |
 | job.env | list | `[]` | Environment variables to pass to job container |
 | job.envFrom | list | `[]` | envFrom to pass to job container |
@@ -60,12 +61,19 @@ A Helm chart for a simple app deployment
 | job.image.repository | string | `"curlimages/curl"` |  |
 | job.image.tag | string | `"8.7.1"` |  |
 | job.imagePullSecrets | list | `[]` |  |
+| job.labels | object | `{}` | Labels to add to the job on top of the common chart labels |
 | job.nodeSelector | object | `{}` | NodeSelector to use for the job pod |
+| job.podAnnotations | object | `{}` | Annotations to add to the job pod |
+| job.podLabels | object | `{}` | Labels to add to the job pod on top of instance, managed-by and component |
 | job.podSecurityContext | object | `{}` | podSecurityContext to use for the job pod |
+| job.resources | object | `{}` | Resources to request for the job container |
 | job.restartPolicy | string | `"Never"` |  |
-| job.securityContext | object | `{}` | securityContext to use for the job pod |
+| job.securityContext | object | `{}` | securityContext to use for the job container |
 | job.serviceAccountName | string | `""` | An override for the job service account |
 | job.tolerations | list | `[]` | Tolerations to use for the job pod |
+| job.ttlSecondsAfterFinished | string | `nil` | Seconds to keep a finished job before the TTL controller removes it |
+| job.volumeMounts | list | `[]` | Raw yaml definition of volume mounts for the job container |
+| job.volumes | list | `[]` | Raw yaml definition of volumes available to the job pod |
 | keda.advanced | object | `{}` |  |
 | keda.enabled | bool | `false` |  |
 | keda.fallback | object | `{}` |  |

--- a/charts/app/templates/job.yaml
+++ b/charts/app/templates/job.yaml
@@ -23,12 +23,13 @@ spec:
   template:
     metadata:
       {{- /* Not app.selectorLabels: that pair is the Service and PodMonitor selector,
-             and job pods matching it would be enrolled as Service endpoints. */}}
+             and job pods matching it would be enrolled as Service endpoints. The
+             omit below stops podLabels reintroducing the half that is missing. */}}
       labels:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: job
-        {{- with .Values.job.podLabels }}
+        {{- with omit .Values.job.podLabels "app.kubernetes.io/name" }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.job.podAnnotations }}

--- a/charts/app/templates/job.yaml
+++ b/charts/app/templates/job.yaml
@@ -1,56 +1,99 @@
-{{ if .Values.job.enabled }}
+{{- if .Values.job.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "app.fullname" . }}-job
-  {{- if .Values.job.annotations }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    {{- with .Values.job.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.job.annotations }}
   annotations:
-    {{ toYaml .Values.job.annotations }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  {{- if not (kindIs "invalid" .Values.job.ttlSecondsAfterFinished) }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  {{- if not (kindIs "invalid" .Values.job.activeDeadlineSeconds) }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  {{- end }}
   template:
+    metadata:
+      {{- /* Not app.selectorLabels: that pair is the Service and PodMonitor selector,
+             and job pods matching it would be enrolled as Service endpoints. */}}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: job
+        {{- with .Values.job.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.job.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      restartPolicy: {{ .Values.job.restartPolicy }}
       {{- with .Values.job.imagePullSecrets }}
       imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- with .Values.job.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: job
+          image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}"
+          imagePullPolicy: {{ .Values.job.image.pullPolicy }}
+          {{- with .Values.job.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.job.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.job.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.nodeSelector }}
+      nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.job.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.job.serviceAccountName }}
-      serviceAccountName: {{ .Values.job.serviceAccountName }}
-      {{- end }}
-      {{- if .Values.job.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.job.podSecurityContext | nindent 8 }}
-      {{- end }}
-      containers:
-        - name: job
-          image: {{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}
-          imagePullPolicy: {{ .Values.job.image.pullPolicy }}
-          command:
-            {{- range .Values.job.command }}
-            - {{ . | quote }}
-            {{- end }}
-          {{- if .Values.job.env }}
-          env:
-          {{- toYaml .Values.job.env | nindent 10 }}
-          {{- end }}
-          {{- if .Values.job.envFrom }}
-          envFrom:
-          {{- toYaml .Values.job.envFrom | nindent 10 }}
-          {{- end }}
-          {{- if .Values.job.securityContext }}
-          securityContext:
-            {{- toYaml .Values.job.securityContext | nindent 12 }}
-          {{- end }}
-      restartPolicy: {{ .Values.job.restartPolicy }}
-      nodeSelector:
-        {{-  toYaml .Values.job.nodeSelector | nindent 8 }}
       {{- with .Values.job.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  backoffLimit: {{ .Values.job.backoffLimit }}
 {{- end }}

--- a/charts/app/tests/job_test.yaml
+++ b/charts/app/tests/job_test.yaml
@@ -159,3 +159,187 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: example-service-account
+
+  - it: should not set annotations by default
+    set:
+      job:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should keep every annotation nested under metadata
+    set:
+      job:
+        enabled: true
+        annotations:
+          "helm.sh/hook": pre-upgrade
+          "helm.sh/hook-delete-policy": before-hook-creation
+          example: example1
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": pre-upgrade
+            "helm.sh/hook-delete-policy": before-hook-creation
+            example: example1
+
+  - it: should set chart labels and additional labels
+    set:
+      job:
+        enabled: true
+        labels:
+          example: example1
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: app
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels.example
+          value: example1
+
+  - it: should set pod labels and pod annotations
+    set:
+      job:
+        enabled: true
+        podLabels:
+          example: example1
+        podAnnotations:
+          example: example2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/component: job
+            example: example1
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            example: example2
+
+  - it: should not label job pods with the service selector pair
+    set:
+      job:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+
+  - it: should render zero second timeouts
+    set:
+      job:
+        enabled: true
+        ttlSecondsAfterFinished: 0
+        activeDeadlineSeconds: 0
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 0
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 0
+
+  - it: should use safe job defaults
+    set:
+      job:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+
+  - it: should set args and resources
+    set:
+      job:
+        enabled: true
+        args: ["-c", "echo test"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -c
+            - echo test
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+  - it: should not set args or resources by default
+    set:
+      job:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].args
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+
+  - it: should set volumes and volumeMounts
+    set:
+      job:
+        enabled: true
+        volumes:
+          - name: config
+            configMap:
+              name: example-configmap
+        volumeMounts:
+          - name: config
+            mountPath: /etc/config
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0]
+          value:
+            name: config
+            configMap:
+              name: example-configmap
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            name: config
+            mountPath: /etc/config
+
+  - it: should set ttlSecondsAfterFinished and activeDeadlineSeconds
+    set:
+      job:
+        enabled: true
+        ttlSecondsAfterFinished: 300
+        activeDeadlineSeconds: 600
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 300
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 600
+
+  - it: should omit optional pod fields when unset
+    set:
+      job:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.ttlSecondsAfterFinished
+      - notExists:
+          path: spec.activeDeadlineSeconds
+      - notExists:
+          path: spec.template.metadata.annotations
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.securityContext
+      - notExists:
+          path: spec.template.spec.volumes

--- a/charts/app/tests/job_test.yaml
+++ b/charts/app/tests/job_test.yaml
@@ -230,6 +230,20 @@ tests:
       - notExists:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
 
+  - it: should ignore a name label supplied through podLabels
+    set:
+      job:
+        enabled: true
+        podLabels:
+          "app.kubernetes.io/name": app
+          example: example1
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+      - equal:
+          path: spec.template.metadata.labels.example
+          value: example1
+
   - it: should render zero second timeouts
     set:
       job:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -183,11 +183,26 @@ job:
     tag: 8.7.1
     pullPolicy: IfNotPresent
   imagePullSecrets: []
+  # -- A job container command override
   command: ["curl", "https://ifconfig.me"]
+  # -- A job container args
+  args: []
   restartPolicy: Never
   backoffLimit: 1
-  annotations:
-    "helm.sh/hook": pre-upgrade
+  # -- Seconds to keep a finished job before the TTL controller removes it
+  ttlSecondsAfterFinished: null
+  # -- Seconds a job may run before it is terminated and marked failed
+  activeDeadlineSeconds: null
+  # -- Annotations to add to the job. Set "helm.sh/hook" here to run the job as a Helm hook
+  annotations: {}
+  #  "helm.sh/hook": pre-upgrade
+  #  "helm.sh/hook-delete-policy": before-hook-creation
+  # -- Labels to add to the job on top of the common chart labels
+  labels: {}
+  # -- Annotations to add to the job pod
+  podAnnotations: {}
+  # -- Labels to add to the job pod on top of instance, managed-by and component
+  podLabels: {}
   # -- An override for the job service account
   serviceAccountName: ""
   # -- NodeSelector to use for the job pod
@@ -196,7 +211,7 @@ job:
   tolerations: []
   # -- Affinity to use for the job pod
   affinity: {}
-  # -- securityContext to use for the job pod
+  # -- securityContext to use for the job container
   securityContext: {}
   #  allowPrivilegeEscalation: false
   #  capabilities:
@@ -206,6 +221,11 @@ job:
   #  runAsUser: 1000
   #  runAsGroup: 1000
   #  fsGroup: 1000
+  # -- Resources to request for the job container
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
   # -- Environment variables to pass to job container
   env: []
   # - name: "ENV_NAME"
@@ -216,6 +236,15 @@ job:
   #     name: config-map-name
   # - secretRef:
   #     name: secret-name
+  # -- Raw yaml definition of volumes available to the job pod
+  volumes: []
+  #  - name: config
+  #    configMap:
+  #      name: config-map-name
+  # -- Raw yaml definition of volume mounts for the job container
+  volumeMounts: []
+  #  - name: config
+  #    mountPath: /etc/config
 
 podMonitor:
   enabled: false

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -201,7 +201,7 @@ job:
   labels: {}
   # -- Annotations to add to the job pod
   podAnnotations: {}
-  # -- Labels to add to the job pod on top of instance, managed-by and component
+  # -- Labels to add to the job pod on top of instance, managed-by and component. app.kubernetes.io/name is ignored: it would enrol job pods as Service endpoints
   podLabels: {}
   # -- An override for the job service account
   serviceAccountName: ""


### PR DESCRIPTION
The job template rendered annotations with `toYaml` but no `nindent`, so every key past the first landed at column 0, outside `metadata`. It only ever looked correct because the shipped default had exactly one key.

Also adds the configuration the job was missing relative to the main app template: `labels`, `podLabels`, `podAnnotations`, `args`, `resources`, `volumes`, `volumeMounts`, `ttlSecondsAfterFinished`, `activeDeadlineSeconds`.

**Breaking:** `job.annotations` no longer defaults to `"helm.sh/hook": pre-upgrade`. Helm merges maps, so that key could not be removed by a values override. Set it explicitly to keep hook semantics; otherwise delete the leftover hook-created job before upgrading, since a job's pod template is immutable.

Job pods carry `instance`, `managed-by` and `component: job` rather than the common selector labels — that pair is the Service and PodMonitor selector, and matching it would enrol job pods as Service endpoints.