### PR TITLE
feat(argo-watcher): expose the Gravatar fallback toggle

### DIFF
--- a/charts/argo-watcher/Chart.yaml
+++ b/charts/argo-watcher/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/shini4i/argo-watcher
 - https://github.com/shini4i/argo-watcher-mcp
 - https://github.com/shini4i/charts/tree/main/charts/argo-watcher
-version: 1.3.0
+version: 1.2.2
 keywords:
 - argocd
 - gitops
@@ -24,5 +24,5 @@ annotations:
     fingerprint: FF1E9948F6234DC6D70AB47BF509F29B63C1DC2B
     url: https://shini4i.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: oidc.gravatarFallback exposes OIDC_GRAVATAR_FALLBACK, letting the Web UI account card fall back to Gravatar
+    - kind: changed
+      description: Update argo-watcher app version from v0.14.0 to v0.15.0

--- a/charts/argo-watcher/Chart.yaml
+++ b/charts/argo-watcher/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/shini4i/argo-watcher
 - https://github.com/shini4i/argo-watcher-mcp
 - https://github.com/shini4i/charts/tree/main/charts/argo-watcher
-version: 1.2.2
+version: 1.3.0
 keywords:
 - argocd
 - gitops
@@ -24,5 +24,5 @@ annotations:
     fingerprint: FF1E9948F6234DC6D70AB47BF509F29B63C1DC2B
     url: https://shini4i.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update argo-watcher app version from v0.14.0 to v0.15.0
+    - kind: added
+      description: oidc.gravatarFallback exposes OIDC_GRAVATAR_FALLBACK, letting the Web UI account card fall back to Gravatar

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -346,7 +346,7 @@ PodMonitor has the same property.
 | oidc | object | `{"clientId":"","enabled":false,"gravatarFallback":false,"issuerUrl":"","privilegedGroups":[],"tokenValidationInterval":10000}` | OIDC / SSO authentication configuration. Requires argo-watcher >= v0.13.0; earlier versions only honor the deprecated KEYCLOAK_* variables, which can be set via extraEnvs. |
 | oidc.clientId | string | `""` | Client ID registered with the identity provider (required when enabled) |
 | oidc.enabled | bool | `false` | Enables OIDC authentication for the Web UI and privileged operations |
-| oidc.gravatarFallback | bool | `false` | Falls back to Gravatar for the account card avatar when the provider sends no picture claim. Off by default: it discloses the user's email address to gravatar.com — hashed, but reversible for any address worth guessing. Requires an argo-watcher release that honors OIDC_GRAVATAR_FALLBACK; older versions ignore it. |
+| oidc.gravatarFallback | bool | `false` | Falls back to Gravatar when the provider sends no picture claim; discloses the user's email address to gravatar.com |
 | oidc.issuerUrl | string | `""` | Identity provider issuer URL used for OIDC discovery, e.g. https://keycloak.example.com/realms/example (required when enabled) |
 | oidc.privilegedGroups | list | `[]` | Groups whose members may redeploy applications and manage the deployment lock |
 | oidc.tokenValidationInterval | int | `10000` | Interval in milliseconds between token validations |

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -1,6 +1,6 @@
 # argo-watcher
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 A Helm chart for deploying argo-watcher
 
@@ -343,9 +343,10 @@ PodMonitor has the same property.
 | networkPolicies.additionalRules | list | `[]` | additional ingress rules to add to the network policy (access will be granted to .Values.service.containerPort) |
 | networkPolicies.enabled | bool | `false` | If network policies should be created |
 | nodeSelector | object | `{}` |  |
-| oidc | object | `{"clientId":"","enabled":false,"issuerUrl":"","privilegedGroups":[],"tokenValidationInterval":10000}` | OIDC / SSO authentication configuration. Requires argo-watcher >= v0.13.0; earlier versions only honor the deprecated KEYCLOAK_* variables, which can be set via extraEnvs. |
+| oidc | object | `{"clientId":"","enabled":false,"gravatarFallback":false,"issuerUrl":"","privilegedGroups":[],"tokenValidationInterval":10000}` | OIDC / SSO authentication configuration. Requires argo-watcher >= v0.13.0; earlier versions only honor the deprecated KEYCLOAK_* variables, which can be set via extraEnvs. |
 | oidc.clientId | string | `""` | Client ID registered with the identity provider (required when enabled) |
 | oidc.enabled | bool | `false` | Enables OIDC authentication for the Web UI and privileged operations |
+| oidc.gravatarFallback | bool | `false` | Falls back to Gravatar for the account card avatar when the provider sends no picture claim. Off by default: it discloses the user's email address to gravatar.com — hashed, but reversible for any address worth guessing. Requires argo-watcher >= v0.16.0 |
 | oidc.issuerUrl | string | `""` | Identity provider issuer URL used for OIDC discovery, e.g. https://keycloak.example.com/realms/example (required when enabled) |
 | oidc.privilegedGroups | list | `[]` | Groups whose members may redeploy applications and manage the deployment lock |
 | oidc.tokenValidationInterval | int | `10000` | Interval in milliseconds between token validations |

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -346,7 +346,7 @@ PodMonitor has the same property.
 | oidc | object | `{"clientId":"","enabled":false,"gravatarFallback":false,"issuerUrl":"","privilegedGroups":[],"tokenValidationInterval":10000}` | OIDC / SSO authentication configuration. Requires argo-watcher >= v0.13.0; earlier versions only honor the deprecated KEYCLOAK_* variables, which can be set via extraEnvs. |
 | oidc.clientId | string | `""` | Client ID registered with the identity provider (required when enabled) |
 | oidc.enabled | bool | `false` | Enables OIDC authentication for the Web UI and privileged operations |
-| oidc.gravatarFallback | bool | `false` | Falls back to Gravatar for the account card avatar when the provider sends no picture claim. Off by default: it discloses the user's email address to gravatar.com — hashed, but reversible for any address worth guessing. Requires argo-watcher >= v0.16.0 |
+| oidc.gravatarFallback | bool | `false` | Falls back to Gravatar for the account card avatar when the provider sends no picture claim. Off by default: it discloses the user's email address to gravatar.com — hashed, but reversible for any address worth guessing. Requires an argo-watcher release that honors OIDC_GRAVATAR_FALLBACK; older versions ignore it. |
 | oidc.issuerUrl | string | `""` | Identity provider issuer URL used for OIDC discovery, e.g. https://keycloak.example.com/realms/example (required when enabled) |
 | oidc.privilegedGroups | list | `[]` | Groups whose members may redeploy applications and manage the deployment lock |
 | oidc.tokenValidationInterval | int | `10000` | Interval in milliseconds between token validations |

--- a/charts/argo-watcher/README.md
+++ b/charts/argo-watcher/README.md
@@ -1,6 +1,6 @@
 # argo-watcher
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 A Helm chart for deploying argo-watcher
 

--- a/charts/argo-watcher/templates/statefulset.yaml
+++ b/charts/argo-watcher/templates/statefulset.yaml
@@ -102,6 +102,10 @@ spec:
             - name: OIDC_PRIVILEGED_GROUPS
               value: {{ join "," . | quote }}
             {{- end }}
+            {{- if .Values.oidc.gravatarFallback }}
+            - name: OIDC_GRAVATAR_FALLBACK
+              value: "true"
+            {{- end }}
             {{- end }}
             - name: STATE_TYPE
               {{- if .Values.postgres.enabled }}

--- a/charts/argo-watcher/tests/statefulset_test.yaml
+++ b/charts/argo-watcher/tests/statefulset_test.yaml
@@ -486,6 +486,33 @@ tests:
             name: OIDC_PRIVILEGED_GROUPS
             value: "platform-team,sre-team"
 
+  - it: should not render the Gravatar fallback unless asked
+    set:
+      oidc:
+        enabled: true
+        issuerUrl: https://keycloak.example.com/realms/example
+        clientId: argo-watcher
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OIDC_GRAVATAR_FALLBACK
+
+  - it: should render the Gravatar fallback when enabled
+    set:
+      oidc:
+        enabled: true
+        issuerUrl: https://keycloak.example.com/realms/example
+        clientId: argo-watcher
+        gravatarFallback: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_GRAVATAR_FALLBACK
+            value: "true"
+
   - it: should render custom OIDC token validation interval
     set:
       oidc:

--- a/charts/argo-watcher/values.schema.json
+++ b/charts/argo-watcher/values.schema.json
@@ -110,7 +110,8 @@
         "privilegedGroups": {
           "type": "array",
           "items": { "type": "string" }
-        }
+        },
+        "gravatarFallback": { "type": "boolean" }
       },
       "required": ["enabled"]
     },

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -104,7 +104,8 @@ oidc:
   # -- Falls back to Gravatar for the account card avatar when the provider sends no
   # picture claim. Off by default: it discloses the user's email address to
   # gravatar.com — hashed, but reversible for any address worth guessing.
-  # Requires argo-watcher >= v0.16.0
+  # Requires an argo-watcher release that honors OIDC_GRAVATAR_FALLBACK; older
+  # versions ignore it.
   gravatarFallback: false
 
 # -- Additional environment variables to add to the container (supports both value and valueFrom)

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -101,6 +101,11 @@ oidc:
   privilegedGroups: []
   #  - platform-team
   #  - sre-team
+  # -- Falls back to Gravatar for the account card avatar when the provider sends no
+  # picture claim. Off by default: it discloses the user's email address to
+  # gravatar.com — hashed, but reversible for any address worth guessing.
+  # Requires argo-watcher >= v0.16.0
+  gravatarFallback: false
 
 # -- Additional environment variables to add to the container (supports both value and valueFrom)
 extraEnvs: []

--- a/charts/argo-watcher/values.yaml
+++ b/charts/argo-watcher/values.yaml
@@ -101,11 +101,7 @@ oidc:
   privilegedGroups: []
   #  - platform-team
   #  - sre-team
-  # -- Falls back to Gravatar for the account card avatar when the provider sends no
-  # picture claim. Off by default: it discloses the user's email address to
-  # gravatar.com — hashed, but reversible for any address worth guessing.
-  # Requires an argo-watcher release that honors OIDC_GRAVATAR_FALLBACK; older
-  # versions ignore it.
+  # -- Falls back to Gravatar when the provider sends no picture claim; discloses the user's email address to gravatar.com
   gravatarFallback: false
 
 # -- Additional environment variables to add to the container (supports both value and valueFrom)


### PR DESCRIPTION
`oidc.gravatarFallback` sets `OIDC_GRAVATAR_FALLBACK`, which lets the Web UI's account card fall back to gravatar.com when the identity provider sends no `picture` claim. Off by default, and only rendered when enabled, because it discloses the user's email address to a third party.

Older argo-watcher versions ignore the variable, so the value is inert until the server release that honors it.